### PR TITLE
Allow 3 part version numbers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           if [[ $GITHUB_REF_NAME == master ]] || [[ $GITHUB_REF_NAME == main ]]; then
             # when building master/main use :latest tag and the version number
             # from the cbpi/__init__.py file
-            VERSION=$(grep -o -E "(([0-9]{1,2}[.]?){3}[0-9]+)" cbpi/__init__.py)
+            VERSION=$(grep -o -E "(([0-9]{1,2}[.]?){2,3}[0-9]+)" cbpi/__init__.py)
             LATEST_IMAGE=${{ env.image-name }}:latest
             BUILD_CACHE_IMAGE_NAME=${LATEST_IMAGE}
             TAGS="${LATEST_IMAGE},${{ env.image-name }}:v${VERSION}"


### PR DESCRIPTION
The version number has been changed recently to only have 3 parts. This was not recognized by the build script, yet. The new regex should allow this now so the build will be successful again.